### PR TITLE
Changes to detect number of clusters from model file

### DIFF
--- a/feature_extract.py
+++ b/feature_extract.py
@@ -134,15 +134,8 @@ def main():
 
     dataset = PlaceDataset(None, opt.dataset_file_path, opt.dataset_root_dir, None, config['feature_extract'])
 
-    # must load from a resume to do extraction
+    # must resume to do extraction
     resume_ckpt = config['global_params']['resumePath'] + config['global_params']['num_pcs'] + '.pth.tar'
-
-    model = get_model(encoder, encoder_dim, opt, config['global_params'], append_pca_layer=True)
-
-    if int(config['global_params']['nGPU']) > 1 and torch.cuda.device_count() > 1:
-        model.encoder = nn.DataParallel(model.encoder)
-        # if opt.mode.lower() != 'cluster':
-        model.pool = nn.DataParallel(model.pool)
 
     # backup: try whether resume_ckpt is relative to PATCHNETVLAD_ROOT_DIR
     if not isfile(resume_ckpt):
@@ -154,6 +147,16 @@ def main():
     if isfile(resume_ckpt):
         print("=> loading checkpoint '{}'".format(resume_ckpt))
         checkpoint = torch.load(resume_ckpt, map_location=lambda storage, loc: storage)
+        assert checkpoint['state_dict']['WPCA.0.bias'].shape[0] == int(config['global_params']['num_pcs'])
+        config['global_params']['num_clusters'] = str(checkpoint['state_dict']['pool.centroids'].shape[0])
+
+        model = get_model(encoder, encoder_dim, opt, config['global_params'], append_pca_layer=True)
+
+        if int(config['global_params']['nGPU']) > 1 and torch.cuda.device_count() > 1:
+            model.encoder = nn.DataParallel(model.encoder)
+            # if opt.mode.lower() != 'cluster':
+            model.pool = nn.DataParallel(model.pool)
+
         model.load_state_dict(checkpoint['state_dict'])
         model = model.to(device)
         print("=> loaded checkpoint '{}'".format(resume_ckpt, ))

--- a/patchnetvlad/configs/performance.ini
+++ b/patchnetvlad/configs/performance.ini
@@ -16,7 +16,6 @@ patchweights2use = 0.45,0.15,0.4
 [global_params]
 pooling = patchnetvlad
 resumepath = ./pretrained_models/mapillary_WPCA
-num_clusters = 16
 threads = 0
 num_pcs = 4096
 ngpu = 1

--- a/patchnetvlad/configs/speed.ini
+++ b/patchnetvlad/configs/speed.ini
@@ -16,7 +16,6 @@ patchweights2use = 1
 [global_params]
 pooling = patchnetvlad
 resumepath = ./pretrained_models/mapillary_WPCA
-num_clusters = 16
 threads = 0
 num_pcs = 512
 ngpu = 1

--- a/patchnetvlad/configs/storage.ini
+++ b/patchnetvlad/configs/storage.ini
@@ -16,7 +16,6 @@ patchweights2use = 1
 [global_params]
 pooling = patchnetvlad
 resumepath = ./pretrained_models/mapillary_WPCA
-num_clusters = 16
 threads = 0
 num_pcs = 128
 ngpu = 1


### PR DESCRIPTION
Fix #10

Do not store the number of clusters in a configuration file, which is prone to errors (see #10). Instead read them from the checkpoint. Also check that the PCA dimension in the configuration file matches that of the checkpoint.

Please review and merge @StephenHausler @oravus :)