### PR TITLE
Fixing val.py incorrect recalls issue #43

### DIFF
--- a/patchnetvlad/training_tools/msls.py
+++ b/patchnetvlad/training_tools/msls.py
@@ -99,6 +99,8 @@ class MSLS(Dataset):
         self.dbImages = []
         self.sideways = []
         self.night = []
+        self.qEndPosList = []
+        self.dbEndPosList = []
 
         self.all_pos_indices = []
 
@@ -185,6 +187,9 @@ class MSLS(Dataset):
 
                 self.qImages.extend(qSeqKeys)
                 self.dbImages.extend(dbSeqKeys)
+
+                self.qEndPosList.append(len(qSeqKeys))
+                self.dbEndPosList.append(len(dbSeqKeys))
 
                 qData = qData.loc[unique_qSeqIdx]
                 dbData = dbData.loc[unique_dbSeqIdx]

--- a/patchnetvlad/training_tools/val.py
+++ b/patchnetvlad/training_tools/val.py
@@ -89,19 +89,15 @@ def val(eval_set, model, encoder_dim, device, opt, config, writer, epoch_num=0, 
     qEndPosTot = 0
     dbEndPosTot = 0
     for cityNum, (qEndPos, dbEndPos) in enumerate(zip(eval_set.qEndPosList, eval_set.dbEndPosList)):
-        qEndPosTot += qEndPos
-        dbEndPosTot += dbEndPos
         faiss_index = faiss.IndexFlatL2(pool_size)
+        faiss_index.add(dbFeat[dbEndPosTot:dbEndPosTot+dbEndPos, :])
+        _, preds = faiss_index.search(qFeat[qEndPosTot:qEndPosTot+qEndPos, :], max(n_values))
         if cityNum == 0:
-            faiss_index.add(dbFeat[:dbEndPos, :])
-            _, preds = faiss_index.search(qFeat[:qEndPos, :], max(n_values))
             predictions = preds
         else:
-            faiss_index.add(dbFeat[prev_dbEndPosTot:dbEndPosTot, :])
-            _, preds = faiss_index.search(qFeat[prev_qEndPosTot:qEndPosTot, :], max(n_values))
             predictions = np.vstack((predictions, preds))
-        prev_qEndPosTot = qEndPosTot
-        prev_dbEndPosTot = dbEndPosTot
+        qEndPosTot += qEndPos
+        dbEndPosTot += dbEndPos
 
     correct_at_n = np.zeros(len(n_values))
     # TODO can we do this on the matrix in one go?

--- a/patchnetvlad/training_tools/val.py
+++ b/patchnetvlad/training_tools/val.py
@@ -82,10 +82,19 @@ def val(eval_set, model, encoder_dim, device, opt, config, writer, epoch_num=0, 
     tqdm.write('====> Calculating recall @ N')
     n_values = [1, 5, 10, 20, 50, 100]
 
-    _, predictions = faiss_index.search(qFeat, max(n_values))
-
     # for each query get those within threshold distance
     gt = eval_set.all_pos_indices
+
+    # hard-coded for CPH and SF. This fixes the val recall issue.
+    cph_faiss_index = faiss.IndexFlatL2(pool_size)
+    cph_faiss_index.add(dbFeat[:12556, :])
+    _, cph_predictions = cph_faiss_index.search(qFeat[:499, :], max(n_values))
+
+    sf_faiss_index = faiss.IndexFlatL2(pool_size)
+    sf_faiss_index.add(dbFeat[12556:, :])
+    _, sf_predictions = sf_faiss_index.search(qFeat[499:, :], max(n_values))
+
+    predictions = np.vstack((cph_predictions, sf_predictions))
 
     correct_at_n = np.zeros(len(n_values))
     # TODO can we do this on the matrix in one go?


### PR DESCRIPTION
Made changes to val.py that should fix the indices issue that was causing low reported recalls for mapillary validation on the cph and sf datasets. Without PCA, the recalls with NetVLAD (with the mapillary trained model) are now: 0.495, 0.65, 0.718, 0.77, 0.83, 0.868.